### PR TITLE
fix(ci): run semantic-release under Node 22

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,11 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
 
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
       - name: Install dependencies
         run: bun install
 
@@ -64,7 +69,10 @@ jobs:
         run: bun run build
 
       - name: Release
-        run: bunx semantic-release
+        # semantic-release v25 requires Node ^22.14 || >=24.10; run it under the
+        # Node set up above rather than via Bun (whose emulated Node version is
+        # rejected by semantic-release's engine check).
+        run: npx semantic-release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
semantic-release v25 requires Node ^22.14 || >=24.10; Bun's emulated Node (24.3.0) is rejected. Set up Node 22 and run `npx semantic-release`. Re-enables the release that failed after #43 merged (1.16.0 was not published).

🤖 Generated with [Claude Code](https://claude.com/claude-code)