### PR TITLE
docs: move the site to observation.robbeverhelst.com and add analytics

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -31,3 +31,4 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./docs
+          cname: observation.robbeverhelst.com

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![npm version](https://img.shields.io/npm/v/observation-js.svg)](https://www.npmjs.com/package/observation-js)
 [![CI](https://github.com/RobbeVerhelst/observation-js/actions/workflows/ci.yml/badge.svg)](https://github.com/RobbeVerhelst/observation-js/actions/workflows/ci.yml)
 [![codecov](https://codecov.io/gh/RobbeVerhelst/observation-js/graph/badge.svg?token=YOUR_CODECOV_TOKEN_PLACEHOLDER)](https://codecov.io/gh/RobbeVerhelst/observation-js)
-[![Documentation](https://img.shields.io/badge/documentation-brightgreen.svg)](https://robbeverhelst.github.io/observation-js/)
+[![Documentation](https://img.shields.io/badge/documentation-brightgreen.svg)](https://observation.robbeverhelst.com/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 A fully-typed TypeScript client for the [waarneming.nl](https://waarneming.nl/api/docs/) API. This library provides an easy-to-use interface for interacting with the API, handling both public (unauthenticated) and private (authenticated) endpoints.
@@ -208,7 +208,7 @@ const temporaryData = await client.species.get(123, {
 });
 ```
 
-For more advanced caching options, such as injecting your own cache implementation, please refer to the `ObservationClientOptions` in the generated [API documentation](https://robbeverhelst.github.io/observation-js/).
+For more advanced caching options, such as injecting your own cache implementation, please refer to the `ObservationClientOptions` in the generated [API documentation](https://observation.robbeverhelst.com/).
 
 ## Interceptors
 

--- a/typedoc.json
+++ b/typedoc.json
@@ -1,13 +1,24 @@
 {
   "$schema": "https://typedoc.org/schema.json",
-  "entryPoints": ["src/index.ts"],
+  "entryPoints": [
+    "src/index.ts"
+  ],
   "out": "docs",
-  "plugin": ["typedoc-material-theme"],
+  "plugin": [
+    "typedoc-material-theme"
+  ],
   "name": "observation-js Documentation",
   "readme": "README.md",
   "themeColor": "#4285F4",
-  "exclude": ["**/*.test.ts", "**/node_modules/**"],
-  "sort": ["source-order"],
+  "exclude": [
+    "**/*.test.ts",
+    "**/node_modules/**"
+  ],
+  "sort": [
+    "source-order"
+  ],
   "excludeInternal": false,
-  "includeVersion": true
+  "includeVersion": true,
+  "customFooterHtml": "<script defer src=\"https://analytics.robbeverhelst.be/script.js\" data-website-id=\"f7ee837a-c1ca-4c88-bfcc-bb65fe4a2913\"></script>",
+  "customFooterHtmlDisableWrapper": true
 }


### PR DESCRIPTION
Moves the typedoc site onto its own subdomain and adds the self-hosted Umami the other sites use.

**No Pages migration was needed.** This repo publishes with `peaceiris/actions-gh-pages`, which takes a `cname` input and writes the file into the published branch — so branch-based Pages handles a custom domain fine. I had assumed this would need moving to the Actions-based deployment first; it does not.

Analytics goes in through typedoc's `customFooterHtml` with `customFooterHtmlDisableWrapper`, which is the supported way to inject a tag with attributes — `customJs` only takes a script file and cannot carry `data-website-id`.

Verified by generating: the tag with the real id appears in the output, 140 pages, 0 errors. The 7 warnings are pre-existing (types referenced but not exported).

DNS is already in place: `observation.robbeverhelst.com` is a CNAME to `robbeverhelst.github.io`, DNS-only. The old `github.io/observation-js` path will 301 to the new domain once Pages picks up the CNAME.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation links to use the custom domain `observation.robbeverhelst.com`.
  * Improved documentation site configuration with custom footer analytics.
* **Chores**
  * Configured documentation deployment for the custom domain.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->